### PR TITLE
Yin-Yang: cycle cell state on click and remove white-mode

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -218,6 +218,13 @@
     "solutionRevealed": "🏳️ Solution Revealed",
     "theAnswerWas": "The answer was: <strong>{{answer}}</strong>"
   },
+  "yinYang": {
+    "title": "Yin-Yang",
+    "instructions": "Fill cells black or white. Each color must be connected. No 2×2 squares of the same color allowed. Tap to cycle black, white, and empty.",
+    "winTitle": "☯️ Balance Achieved!",
+    "winMessage": "Yin and Yang in harmony!",
+    "legendCycle": "Click: Cycle black → white → empty"
+  },
   "profile": {
     "title": "Profile",
     "security": "Security",

--- a/src/pages/YinYang/YinYang.jsx
+++ b/src/pages/YinYang/YinYang.jsx
@@ -155,6 +155,12 @@ function checkSolved(grid, solution, size) {
   return true;
 }
 
+function getNextCellState(current) {
+  if (current === null) return true;
+  if (current === true) return false;
+  return null;
+}
+
 // Export helpers for testing
 export {
   DIFFICULTIES,
@@ -164,6 +170,7 @@ export {
   has2x2Square,
   checkValidity,
   checkSolved,
+  getNextCellState,
 };
 
 export default function YinYang() {
@@ -175,7 +182,6 @@ export default function YinYang() {
   const { gameState, checkWin, giveUp, reset: resetGameState, isPlaying } = useGameState();
   const [errors, setErrors] = useState(new Set());
   const [showErrors, setShowErrors] = useState(false);
-  const [whiteMode, setWhiteMode] = useState(false); // Mobile white mode
 
   const availableSizes = useMemo(() => getAvailableSizes(difficulty), [difficulty]);
 
@@ -231,24 +237,13 @@ export default function YinYang() {
     if (!isPlaying) return;
     if (puzzleData.puzzle[r][c] !== null) return; // Can't change given cells
 
-    const isWhiteAction = e.type === 'contextmenu' || e.ctrlKey || whiteMode;
+    if (e.type === 'contextmenu') e.preventDefault();
 
-    if (isWhiteAction) {
-      if (e.type === 'contextmenu') e.preventDefault();
-      // Place white
-      setGrid(prev => {
-        const newGrid = prev.map(row => [...row]);
-        newGrid[r][c] = newGrid[r][c] === false ? null : false;
-        return newGrid;
-      });
-    } else {
-      // Place black
-      setGrid(prev => {
-        const newGrid = prev.map(row => [...row]);
-        newGrid[r][c] = newGrid[r][c] === true ? null : true;
-        return newGrid;
-      });
-    }
+    setGrid(prev => {
+      const newGrid = prev.map(row => [...row]);
+      newGrid[r][c] = getNextCellState(newGrid[r][c]);
+      return newGrid;
+    });
   };
 
   const handleReset = () => {
@@ -267,8 +262,11 @@ export default function YinYang() {
   return (
     <div className={styles.container}>
       <GameHeader
-        title="Yin-Yang"
-        instructions="Fill cells black or white. Each color must be connected. No 2×2 squares of the same color allowed. Tap for black, use white mode for white."
+        title={t('yinYang.title', 'Yin-Yang')}
+        instructions={t(
+          'yinYang.instructions',
+          'Fill cells black or white. Each color must be connected. No 2×2 squares of the same color allowed. Tap to cycle black, white, and empty.'
+        )}
       />
 
       <DifficultySelector
@@ -286,14 +284,6 @@ export default function YinYang() {
       />
 
       <div className={styles.gameArea}>
-        {/* Mobile White Toggle */}
-        <button
-          className={`${styles.whiteToggle} ${whiteMode ? styles.whiteModeActive : ''}`}
-          onClick={() => setWhiteMode(!whiteMode)}
-        >
-          ○ {whiteMode ? 'White Mode ON' : 'White Mode'}
-        </button>
-
         <div
           className={styles.grid}
           style={{ gridTemplateColumns: `repeat(${size}, 1fr)` }}
@@ -327,17 +317,17 @@ export default function YinYang() {
         {gameState === 'won' && (
           <GameResult
             state="won"
-            title="☯️ Balance Achieved!"
-            message="Yin and Yang in harmony!"
-            actions={[{ label: 'New Puzzle', onClick: initGame, primary: true }]}
+            title={t('yinYang.winTitle', '☯️ Balance Achieved!')}
+            message={t('yinYang.winMessage', 'Yin and Yang in harmony!')}
+            actions={[{ label: t('common.newPuzzle', 'New Puzzle'), onClick: initGame, primary: true }]}
           />
         )}
 
         {gameState === 'gaveUp' && (
           <GameResult
             state="gaveup"
-            message="Better luck next time!"
-            actions={[{ label: 'New Puzzle', onClick: initGame, primary: true }]}
+            message={t('common.betterLuckNextTime', 'Better luck next time!')}
+            actions={[{ label: t('common.newPuzzle', 'New Puzzle'), onClick: initGame, primary: true }]}
           />
         )}
 
@@ -349,26 +339,25 @@ export default function YinYang() {
               onChange={(e) => setShowErrors(e.target.checked)}
             />
             <span className={styles.toggleSlider}></span>
-            Show errors
+            {t('common.showErrors', 'Show errors')}
           </label>
         </div>
 
         <div className={styles.buttons}>
           <button className={styles.resetBtn} onClick={handleReset}>
-            Reset
+            {t('common.reset', 'Reset')}
           </button>
           <GiveUpButton
             onGiveUp={handleGiveUp}
             disabled={!isPlaying}
           />
           <button className={styles.newGameBtn} onClick={initGame}>
-            New Puzzle
+            {t('common.newPuzzle', 'New Puzzle')}
           </button>
         </div>
 
         <div className={styles.legend}>
-          <span>Click: Black</span>
-          <span>Right-click: White</span>
+          <span>{t('yinYang.legendCycle', 'Click: Cycle black → white → empty')}</span>
         </div>
       </div>
     </div>

--- a/src/pages/YinYang/YinYang.module.css
+++ b/src/pages/YinYang/YinYang.module.css
@@ -5,33 +5,6 @@
   color: var(--color-text);
 }
 
-/* Mobile White Toggle */
-.whiteToggle {
-  padding: 0.6rem 1.25rem;
-  background: var(--btn-secondary-bg);
-  border: 1px solid var(--panel-border);
-  border-radius: 8px;
-  color: var(--color-text-secondary);
-  font-size: 0.9rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 1rem;
-}
-
-.whiteToggle:hover {
-  background: rgba(255, 255, 255, 0.12);
-}
-
-.whiteToggle.whiteModeActive {
-  background: var(--btn-secondary-hover-bg);
-  border-color: rgba(255, 255, 255, 0.4);
-  color: var(--color-text);
-}
-
 .header {
   text-align: center;
   margin-bottom: 20px;

--- a/src/pages/YinYang/YinYang.test.js
+++ b/src/pages/YinYang/YinYang.test.js
@@ -7,6 +7,7 @@ import {
   has2x2Square,
   checkValidity,
   checkSolved,
+  getNextCellState,
 } from './YinYang.jsx';
 
 describe('YinYang - helpers', () => {
@@ -50,5 +51,11 @@ describe('YinYang - helpers', () => {
       [false, true],
     ];
     expect(checkSolved(solution, solution, 2)).toBe(true);
+  });
+
+  it('cycles cells from empty to black to white to empty', () => {
+    expect(getNextCellState(null)).toBe(true);
+    expect(getNextCellState(true)).toBe(false);
+    expect(getNextCellState(false)).toBe(null);
   });
 });


### PR DESCRIPTION
### Motivation
- Simplify the Yin-Yang input model so a single click cycles a cell through black, white, and empty instead of requiring a separate "white mode" toggle or right-click.
- Make UI strings translatable via existing i18n keys and remove the mobile white-mode control to reduce UI complexity.

### Description
- Added a `getNextCellState` helper that cycles `null -> true -> false -> null` and exported it for tests.
- Replaced the previous white/black toggle logic in the click handler with a single cycle implementation that calls `getNextCellState` and prevents the contextmenu default behavior.
- Removed the `whiteMode` state and the mobile white-mode button markup and corresponding CSS rules from `YinYang.module.css`.
- Replaced hardcoded strings with i18n calls and added `yinYang` entries to `src/i18n/locales/en.json` for title, instructions, win text, and legend.
- Added a unit test for `getNextCellState` in `src/pages/YinYang/YinYang.test.js` and exported the helper for testing.

### Testing
- Ran the unit test file with `npm run test:run -- src/pages/YinYang/YinYang.test.js` and all tests passed: 1 test file, 6 tests, 6 passed.
- No automated UI/browser tests were executed as part of this patch; a manual screenshot attempt failed to reach the running dev server and is not part of the automated test results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698323cded048325b0e062180667b109)