### PR TITLE
Add NO_AUTH toggle and robust session handling in auth middleware

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,6 +89,7 @@ ENV PORT=3000
 ENV DB_PATH=/app/data/enigma.db
 ENV SERVE_STATIC=true
 ENV STATIC_PATH=/app/public
+ENV NO_AUTH=0
 
 # Expose port
 EXPOSE 3000

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,6 +1,46 @@
 // Authentication middleware
+import db from '../db.js';
+
+const NO_AUTH_USERNAME = 'noauth';
+const NO_AUTH_DISPLAY_NAME = 'No Auth User';
+
+function isNoAuthEnabled() {
+  return process.env.NO_AUTH === '1' || process.env.NO_AUTH === 'true';
+}
+
+function ensureNoAuthUser() {
+  const user = db.prepare('SELECT id, role FROM users WHERE username = ?').get(NO_AUTH_USERNAME);
+  if (user) {
+    return user;
+  }
+
+  const result = db.prepare(`
+    INSERT INTO users (username, password_hash, display_name, role)
+    VALUES (?, ?, ?, ?)
+  `).run(NO_AUTH_USERNAME, 'no-auth', NO_AUTH_DISPLAY_NAME, 'admin');
+
+  const userId = result.lastInsertRowid;
+
+  db.prepare('INSERT INTO user_settings (user_id) VALUES (?)').run(userId);
+
+  return { id: userId, role: 'admin' };
+}
+
+function applyNoAuthSession(req) {
+  const user = ensureNoAuthUser();
+  if (!req.session) {
+    req.session = {};
+  }
+  req.session.userId = user.id;
+  req.session.role = user.role;
+}
 
 export function requireAuth(req, res, next) {
+  if (isNoAuthEnabled()) {
+    applyNoAuthSession(req);
+    return next();
+  }
+
   if (!req.session.userId) {
     return res.status(401).json({ error: 'Authentication required' });
   }
@@ -8,6 +48,11 @@ export function requireAuth(req, res, next) {
 }
 
 export function requireAdmin(req, res, next) {
+  if (isNoAuthEnabled()) {
+    applyNoAuthSession(req);
+    return next();
+  }
+
   if (!req.session.userId) {
     return res.status(401).json({ error: 'Authentication required' });
   }

--- a/backend/src/middleware/auth.test.js
+++ b/backend/src/middleware/auth.test.js
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../db.js', () => ({
+  default: { prepare: vi.fn() }
+}));
+
+import db from '../db.js';
+
+const createRes = () => {
+  const res = {};
+  res.status = vi.fn(() => res);
+  res.json = vi.fn(() => res);
+  return res;
+};
+
+describe('auth middleware', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    delete process.env.NO_AUTH;
+  });
+
+  it('rejects unauthenticated requests when NO_AUTH is disabled', async () => {
+    const { requireAuth } = await import('./auth.js');
+    const req = { session: {} };
+    const res = createRes();
+    const next = vi.fn();
+
+    requireAuth(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Authentication required' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-admin requests when NO_AUTH is disabled', async () => {
+    const { requireAdmin } = await import('./auth.js');
+    const req = { session: { userId: 1, role: 'user' } };
+    const res = createRes();
+    const next = vi.fn();
+
+    requireAdmin(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Admin access required' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('injects a no-auth session user when NO_AUTH is enabled', async () => {
+    process.env.NO_AUTH = '1';
+    const selectGet = vi.fn(() => null);
+    const insertRun = vi.fn(() => ({ lastInsertRowid: 42 }));
+    const settingsRun = vi.fn();
+
+    db.prepare = vi.fn((sql) => {
+      if (sql.includes('SELECT id, role FROM users')) {
+        return { get: selectGet };
+      }
+      if (sql.includes('INSERT INTO users')) {
+        return { run: insertRun };
+      }
+      if (sql.includes('INSERT INTO user_settings')) {
+        return { run: settingsRun };
+      }
+      throw new Error(`Unexpected SQL: ${sql}`);
+    });
+
+    const { requireAuth } = await import('./auth.js');
+    const req = { session: {} };
+    const res = createRes();
+    const next = vi.fn();
+
+    requireAuth(req, res, next);
+
+    expect(selectGet).toHaveBeenCalled();
+    expect(insertRun).toHaveBeenCalled();
+    expect(settingsRun).toHaveBeenCalled();
+    expect(req.session).toEqual({ userId: 42, role: 'admin' });
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('creates a session object when NO_AUTH is enabled and session is missing', async () => {
+    process.env.NO_AUTH = 'true';
+    const selectGet = vi.fn(() => ({ id: 7, role: 'admin' }));
+
+    db.prepare = vi.fn((sql) => {
+      if (sql.includes('SELECT id, role FROM users')) {
+        return { get: selectGet };
+      }
+      throw new Error(`Unexpected SQL: ${sql}`);
+    });
+
+    const { requireAdmin } = await import('./auth.js');
+    const req = {};
+    const res = createRes();
+    const next = vi.fn();
+
+    requireAdmin(req, res, next);
+
+    expect(selectGet).toHaveBeenCalled();
+    expect(req.session).toEqual({ userId: 7, role: 'admin' });
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/env.example
+++ b/env.example
@@ -21,3 +21,6 @@ NODE_ENV=development
 
 # Debug Env Variables
 DEV=0
+
+# Disable authentication (1/true enables auto-login as a single admin user)
+NO_AUTH=0


### PR DESCRIPTION
### Motivation

- Allow disabling authentication for single-user or simplified deployments by providing a `NO_AUTH` toggle that causes requests to act as a single admin user.
- Prevent runtime errors when middleware attempts to inject a session but `req.session` is missing.
- Make the NO_AUTH flow deterministic and covered by unit tests so behavior is safe and testable.

### Description

- Implemented `isNoAuthEnabled()` in `backend/src/middleware/auth.js` and short-circuited `requireAuth`/`requireAdmin` to auto-provision and inject a `noauth` admin user when enabled.
- Added `ensureNoAuthUser()` to create a persistent `noauth` user and related `user_settings` row if missing, and `applyNoAuthSession()` to inject `userId` and `role` while ensuring `req.session` exists.
- Added `backend/src/middleware/auth.test.js` with `vitest` tests that mock `db` and cover normal auth enforcement, NO_AUTH provisioning, and the case where `req.session` is initially missing.
- Documented the option by adding `NO_AUTH=0` to `env.example` and adding `ENV NO_AUTH=0` to the `Dockerfile` for visibility in production images.

### Testing

- Ran the unit tests for the middleware with `cd backend && npm test -- --run src/middleware/auth.test.js` and all tests passed.
- Test results: `1 file passed (src/middleware/auth.test.js)`, `4 tests passed` and the `vitest` run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983244db5988325be7e0d96458678bf)