### PR TITLE
Potential fix for code scanning alert no. 50: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -88,6 +88,7 @@ jobs:
   # Test the published Docker image to ensure it works correctly
   test-image:
     runs-on: ubuntu-latest
+    permissions: {}
     needs: build-and-push
     if: success()
 


### PR DESCRIPTION
Potential fix for [https://github.com/ianfhunter/Enigma/security/code-scanning/50](https://github.com/ianfhunter/Enigma/security/code-scanning/50)

In general, the fix is to define explicit `permissions` for every job (or at the workflow root) so that the GITHUB_TOKEN has only the scopes actually required. Jobs which don’t need to write to the repository normally only need `contents: read`, or even `permissions: {}` if they do not require the token at all.

For this workflow, the `build-and-push` job already defines:

```yaml
permissions:
  contents: read
  packages: write
```

The `test-image` job only pulls and runs Docker images and performs HTTP checks; it does not interact with the repository or GitHub APIs. It therefore does not need any GITHUB_TOKEN permissions. The safest, least-privilege configuration is to add a `permissions: {}` block directly under the `test-image` job so that this job receives a token with no scopes at all. No imports or additional methods are required; this is a pure YAML change in `.github/workflows/docker-publish.yml`.

Concretely, in `.github/workflows/docker-publish.yml`, under:

```yaml
88:   # Test the published Docker image to ensure it works correctly
89:   test-image:
90:     runs-on: ubuntu-latest
91:     needs: build-and-push
92:     if: success()
```

insert a `permissions: {}` line (with correct indentation) after `runs-on: ubuntu-latest` and before `needs: build-and-push`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
