### PR TITLE
Enable ABC End View size options (5x5/6x6/7x7)

### DIFF
--- a/src/pages/ABCEndView/ABCEndView.jsx
+++ b/src/pages/ABCEndView/ABCEndView.jsx
@@ -405,9 +405,9 @@ export default function ABCEndView() {
       />
 
       <SizeSelector
-        sizes={AVAILABLE_SIZES}
-        selectedSize={size}
-        onSizeChange={setSize}
+        options={AVAILABLE_SIZES}
+        value={size}
+        onChange={setSize}
       />
 
       <div className={styles.gameArea}>

--- a/src/pages/ABCEndView/ABCEndView.test.js
+++ b/src/pages/ABCEndView/ABCEndView.test.js
@@ -284,3 +284,18 @@ describe('ABCEndView - Solution Check', () => {
     expect(checkSolved(lowercaseGrid, solution, 4)).toBe(true);
   });
 });
+
+
+// ===========================================
+// ABCEndView - Size Availability Tests
+// ===========================================
+describe('ABCEndView - Size Availability', () => {
+  it('should include 5x5, 6x6, and 7x7 puzzles in the dataset', async () => {
+    const puzzleDataset = await import('../../../public/datasets/abcendviewPuzzles.json');
+    const availableSizes = [...new Set(puzzleDataset.default.puzzles.map(p => p.rows))].sort((a, b) => a - b);
+
+    expect(availableSizes).toContain(5);
+    expect(availableSizes).toContain(6);
+    expect(availableSizes).toContain(7);
+  });
+});


### PR DESCRIPTION
### Motivation
- The ABC End View size selector was passing the wrong prop names to the shared `SizeSelector` component which prevented dataset-backed sizes from being selectable, so larger sizes (5x5, 6x6, 7x7) were not exposed in the UI.
- Add a small guard test to ensure the ABC End View dataset continues to include 5x5/6x6/7x7 puzzles.

### Description
- Updated the `ABCEndView` page to use the correct `SizeSelector` prop names by replacing `sizes`, `selectedSize`, and `onSizeChange` with `options`, `value`, and `onChange` in `src/pages/ABCEndView/ABCEndView.jsx`.
- Added a Vitest test in `src/pages/ABCEndView/ABCEndView.test.js` that imports the dataset and asserts the available sizes include `5`, `6`, and `7`.
- Left dataset discovery logic (`AVAILABLE_SIZES`) intact so the selector will present sizes present in `public/datasets/abcendviewPuzzles.json`.

### Testing
- Ran `npm run test:run -- src/pages/ABCEndView/ABCEndView.test.js` and the test file passed (`12` tests passed).
- Attempted a Playwright screenshot of the running UI to visually confirm the selector, but Chromium crashed in this environment (SIGSEGV) so no screenshot was captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698db9a990948325acebeca494243334)